### PR TITLE
split up storage ids

### DIFF
--- a/TheCommunityDZ.cfg
+++ b/TheCommunityDZ.cfg
@@ -34,7 +34,7 @@ guaranteedUpdates=1;        // Communication protocol used with game server (use
 loginQueueConcurrentPlayers=5;  // The number of players concurrently processed during the login process. Should prevent massive performance drop during connection when a lot of people are connecting at the same time.
 loginQueueMaxPlayers=10;       // The maximum number of players that can wait in login queue
  
-instanceId = 666;             // DayZ server instance id, to identify the number of instances per box and their storage folders with persistence files
+instanceId = 420;             // DayZ server instance id, to identify the number of instances per box and their storage folders with persistence files
 
 storeHouseStateDisabled = false;// Disable houses/doors persistence (value true/false), usable in case of problems with persistence
 storageAutoFix = 1;         // Checks if the persistence files are corrupted and replaces corrupted ones with empty ones (value 0-1)


### PR DESCRIPTION
make live server its own storage id and stop pushing test storage to live server